### PR TITLE
ignore the CDPATH value at "cd" and add more error checks

### DIFF
--- a/simple-setup.sh
+++ b/simple-setup.sh
@@ -62,7 +62,7 @@ cd ./"$BUILD_DIRECTORY"
 
 if [ "$?" -ne "0" ]
 then
-    echo "Directory change to build director failed"
+    echo "Directory change to build directory failed"
     exit 7;
 fi
 


### PR DESCRIPTION
Hopefully this change will fix the build for alonzotg.

For compiling and running KTechlab, the following commands should be enough:

sh simple-setup.sh
sh simple-launch.sh
