### PR TITLE
mime types: add magic pattern to the circuit file type and fix the circuit-opened-as-text problem

### DIFF
--- a/src/ktechlab.xml
+++ b/src/ktechlab.xml
@@ -4,6 +4,9 @@
 		<comment xml:lang="en">KTechLab Circuit</comment>
 		<glob pattern="*.circuit" />
 		<generic-icon name="x-ktechlab-circuit" />
+		<magic priority="50">
+			<match type="string" offset="0" value="&lt;!DOCTYPE KTechlab&gt;\n&lt;document type=&quot;circuit&quot;"/>
+		</magic>
 	</mime-type>
 	<mime-type type="application/x-flowcode">
 		<comment xml:lang="en">KTechLab FlowCode</comment>


### PR DESCRIPTION
this fixes the mimetype identification of circuit files on systems where the .circuit filetype is defined in multiple mime databases.
the beginning of the file is verified for a matching header, so the .circuit file won't be text/plain anymore.

Please note that we might need similar magic matching rule for the flowcode files, too.
