### PR TITLE
buildsystem : allow to build with gcc6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ find_package(GPSim)
 #add_definitions ( -DQT3_SUPPORT )
 #add_definitions ( -DQT3_SUPPORT_WARNINGS )
 
+# fix build with gcc6 which triggers narrowing conversion errors
+# these errors should be fixed properly later while porting to C++11 standards
+# see https://gcc.gnu.org/gcc-6/porting_to.html for details
+add_definitions ( -std=gnu++98 )
+
 if (KTECHLAB_DEVELOPER_BUILD)
 # for debugging with GCC 5
     add_definitions( -fno-omit-frame-pointer )


### PR DESCRIPTION
GCC 6 defaults to -std=gnu++14 instead of -std=gnu++98: the C++14 standard, plus GNU extensions.
This brings several changes that users should be aware of, some new with the C++14 standard, others that appeared with the C++11 standard.
See https://gcc.gnu.org/gcc-6/porting_to.html

I'm not really sure how this errors should be fixed as PPRDATA and so comes from linux/ppdev.h and are defined like this ``#define PPRDATA		_IOR(PP_IOCTL, 0x85, unsigned char)`` anyway this can be done later while doing C++11 port :-)