### PR TITLE
Use angleDelta for zooming with mouse

### DIFF
--- a/src/itemview.cpp
+++ b/src/itemview.cpp
@@ -453,7 +453,7 @@ void ItemView::contentsWheelEvent(QWheelEvent *e)
     if (eventInfo.ctrlPressed) {
         // Zooming in or out
 
-        if (eventInfo.pixelDelta.y() > 0)
+        if (eventInfo.angleDelta.y() > 0)
             zoomIn(eventInfo.pos);
         else
             zoomOut(eventInfo.pos);


### PR DESCRIPTION
Currently holding ctrl and scrolling the mouse wheel always zooms out. This fixes that (at least on my system).